### PR TITLE
Dash usage indicator using SpriteRenderer value

### DIFF
--- a/Where_Is_My_Wife/Assets/_Main/Assets/Player/Prefabs/Player.prefab
+++ b/Where_Is_My_Wife/Assets/_Main/Assets/Player/Prefabs/Player.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a865b440ed4df9cff4eaff05d8a37d86f8062ea8538d28aa4047a35e498be1f
+oid sha256:519678852329edf88522fbca05f4c417668fc4fe52b6531224a4dd94984e585d
 size 44124

--- a/Where_Is_My_Wife/Assets/_Main/Assets/Player/Prefabs/Player.prefab
+++ b/Where_Is_My_Wife/Assets/_Main/Assets/Player/Prefabs/Player.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bff303499f159bd40de3c86101044ab47cd278a9209c14555515a4d7626998dc
-size 44064
+oid sha256:4a865b440ed4df9cff4eaff05d8a37d86f8062ea8538d28aa4047a35e498be1f
+size 44124

--- a/Where_Is_My_Wife/Assets/_Main/Scripts/Player/Controller/PlayerController.cs
+++ b/Where_Is_My_Wife/Assets/_Main/Scripts/Player/Controller/PlayerController.cs
@@ -1,4 +1,5 @@
 using System;
+using DG.Tweening;
 using UnityEngine;
 using WhereIsMyWife.Managers;
 using WhereIsMyWife.Player.State;
@@ -30,14 +31,17 @@ namespace WhereIsMyWife.Controllers
         private IPlayerStateInput _playerStateInput;
         private IPlayerControllerEvent _playerControllerEvent;
         private IRespawn _respawn;
-
+        
         [SerializeField] private Rigidbody2D _rigidbody2D;
         [SerializeField] private Transform _groundCheckTransform = null;
         [SerializeField] private Transform _wallHangCheckUpTransform = null;
         [SerializeField] private Transform _wallHangCheckDownTransform = null;
         [SerializeField] private SpriteRenderer _spriteRenderer = null;
         [SerializeField, Range(0, 1)] private float _dashColorValue = 0.4f;
+        [SerializeField] private Ease _dashColorEase = Ease.OutSine;
+        [SerializeField] private float _dashColorDuration = 0.5f;
 
+        private Tween _dashColorTween;
         private Vector2 _velocityBeforePause;
         private float _gravityScaleBeforePause;
         
@@ -155,6 +159,7 @@ namespace WhereIsMyWife.Controllers
 
         private void Dash(float speed)
         {
+            _dashColorTween?.Kill();
             _spriteRenderer.color = Color.HSVToRGB(0, 0, _dashColorValue);
             
             FaceDirection(speed > 0);
@@ -163,7 +168,7 @@ namespace WhereIsMyWife.Controllers
 
         private void Land()
         {
-            _spriteRenderer.color = Color.white;
+            _dashColorTween = _spriteRenderer.DOColor(Color.white, _dashColorDuration).SetEase(_dashColorEase);
         }
         
         private void SetHorizontalSpeed(float speed)

--- a/Where_Is_My_Wife/Assets/_Main/Scripts/Player/Controller/PlayerController.cs
+++ b/Where_Is_My_Wife/Assets/_Main/Scripts/Player/Controller/PlayerController.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using WhereIsMyWife.Managers;
+using WhereIsMyWife.Player.State;
 
 namespace WhereIsMyWife.Controllers
 {
@@ -26,20 +27,16 @@ namespace WhereIsMyWife.Controllers
         private IPunchingStateEvents _punchingStateEvents;
 
         private IPlayerStateIndicator _playerStateIndicator;
+        private IPlayerStateInput _playerStateInput;
         private IPlayerControllerEvent _playerControllerEvent;
         private IRespawn _respawn;
 
-        [SerializeField]
-        private Rigidbody2D _rigidbody2D;
-
-        [SerializeField]
-        private Transform _groundCheckTransform = null;
-
-        [SerializeField]
-        private Transform _wallHangCheckUpTransform = null;
-
-        [SerializeField]
-        private Transform _wallHangCheckDownTransform = null;
+        [SerializeField] private Rigidbody2D _rigidbody2D;
+        [SerializeField] private Transform _groundCheckTransform = null;
+        [SerializeField] private Transform _wallHangCheckUpTransform = null;
+        [SerializeField] private Transform _wallHangCheckDownTransform = null;
+        [SerializeField] private SpriteRenderer _spriteRenderer = null;
+        [SerializeField, Range(0, 1)] private float _dashColorValue = 0.4f;
 
         private Vector2 _velocityBeforePause;
         private float _gravityScaleBeforePause;
@@ -54,6 +51,7 @@ namespace WhereIsMyWife.Controllers
             _punchingStateEvents = PlayerManager.Instance.PunchingStateEvents;
 
             _playerStateIndicator = PlayerManager.Instance.PlayerStateIndicator;
+            _playerStateInput = PlayerManager.Instance.PlayerStateInput;
             _playerControllerEvent = PlayerManager.Instance.PlayerControllerEvent;
             _respawn = PlayerManager.Instance.Respawn;
 
@@ -157,8 +155,15 @@ namespace WhereIsMyWife.Controllers
 
         private void Dash(float speed)
         {
+            _spriteRenderer.color = Color.HSVToRGB(0, 0, _dashColorValue);
+            
             FaceDirection(speed > 0);
             SetHorizontalSpeed(speed);
+        }
+
+        private void Land()
+        {
+            _spriteRenderer.color = Color.white;
         }
         
         private void SetHorizontalSpeed(float speed)
@@ -243,6 +248,8 @@ namespace WhereIsMyWife.Controllers
             _punchingStateEvents.JumpStart += JumpStart;
             _punchingStateEvents.GravityScale += SetGravityScale;
             _punchingStateEvents.FallSpeedCap += SetFallSpeedCap;
+            
+            _playerStateInput.Land += Land;
         }
 
         private void UnsubscribeFromStateEvents()
@@ -274,6 +281,8 @@ namespace WhereIsMyWife.Controllers
             _punchingStateEvents.JumpStart -= JumpStart;
             _punchingStateEvents.GravityScale -= SetGravityScale;
             _punchingStateEvents.FallSpeedCap -= SetFallSpeedCap;
+            
+            _playerStateInput.Land -= Land;
         }
 
         private void SubscribeToRespawnEvents()


### PR DESCRIPTION
Closes #111 

It decreases the player sprite HSV value to make it darker and uses the PlayerManager Land event to reset the color back to white.

Working correctly:

https://github.com/user-attachments/assets/ac420e0d-19f3-40b9-b223-505da0dabdac

Color reset Tween:

https://github.com/user-attachments/assets/e9d445af-e49a-4a12-8cc1-e1f540d13a9a
