### PR TITLE
Combined mountain level fixes with level end reveal

### DIFF
--- a/Where_Is_My_Wife/Assets/_Main/Scenes/Levels/MountainLevel.unity
+++ b/Where_Is_My_Wife/Assets/_Main/Scenes/Levels/MountainLevel.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f16f8ac2dd5ce1941f5e1491177b921b90d1720b387b8f6faec7b2bf9804ad58
-size 152722990
+oid sha256:2854947d2b94baff19feb16a334fcb1909d6ac1fdec7432a5951ce1f69a8e93a
+size 153335727


### PR DESCRIPTION
When I implemented the level end reveal I had an outdated version of MountainLevel that didn't include Shasho's fixes. I cherrypicked the commit again and applied the reveal to it.